### PR TITLE
Syntax highlighting with bat

### DIFF
--- a/config/bat/config
+++ b/config/bat/config
@@ -1,0 +1,31 @@
+# This is `bat`s configuration file. Each line either contains a comment or
+# a command-line option that you want to pass to `bat` by default. You can
+# run `bat --help` to get a list of all possible configuration options.
+
+# Specify desired highlighting theme (e.g. "TwoDark"). Run `bat --list-themes`
+# for a list of all available themes
+#--theme="TwoDark"
+
+# Enable this to use italic text on the terminal. This is not supported on all
+# terminal emulators (like tmux, by default):
+#--italic-text=always
+
+# Uncomment the following line to disable automatic paging:
+#--paging=never
+
+# Uncomment the following line if you are using less version >= 551 and want to
+# enable mouse scrolling support in `bat` when running inside tmux. This might
+# disable text selection, unless you press shift.
+#--pager="less --RAW-CONTROL-CHARS --quit-if-one-screen --mouse"
+
+# Syntax mappings: map a certain filename pattern to a language.
+#   Example 1: use the C++ syntax for Arduino .ino files
+#   Example 2: Use ".gitignore"-style highlighting for ".ignore" files
+#--map-syntax "*.ino:C++"
+#--map-syntax ".ignore:Git Ignore"
+--map-syntax "Brewfile:Bourne Again Shell (bash)"
+--map-syntax ".aliases:Bourne Again Shell (bash)"
+--map-syntax ".functions:Bourne Again Shell (bash)"
+--map-syntax "zshrc:Bourne Again Shell (bash)"
+--map-syntax "zshenv:Bourne Again Shell (bash)"
+--map-syntax "Brewfile:Bourne Again Shell (bash)"

--- a/config/bat/config
+++ b/config/bat/config
@@ -26,6 +26,8 @@
 --map-syntax "Brewfile:Bourne Again Shell (bash)"
 --map-syntax ".aliases:Bourne Again Shell (bash)"
 --map-syntax ".functions:Bourne Again Shell (bash)"
+--map-syntax "aliases:Bourne Again Shell (bash)"
+--map-syntax "functions:Bourne Again Shell (bash)"
 --map-syntax "zshrc:Bourne Again Shell (bash)"
 --map-syntax "zshenv:Bourne Again Shell (bash)"
 --map-syntax "Brewfile:Bourne Again Shell (bash)"

--- a/home/functions
+++ b/home/functions
@@ -1,5 +1,5 @@
 # Make director(y|ies) and cd into the directory.
-mkcd() {
+function mkcd() {
   mkdir -p "$@" && cd "$_"
 }
 

--- a/home/functions
+++ b/home/functions
@@ -1,11 +1,10 @@
 # Make director(y|ies) and cd into the directory.
-function mkcd() {
+mkcd() {
   mkdir -p "$@" && cd "$_"
 }
 
-# Highlighting --help messages with bat
-# Make sure `alias bathelp="bat --plain --language=help"`
-# exits before this function.
-function help() {
-  "$@" --help 2>&1 | bathelp
-}
+# Highlighting `--help` messages
+# help()( {
+#   "@" --help 2>&1 | bat -plhelp
+#   # "@" --help 2>&1 | bat --plain --language=help
+# }

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -20,12 +20,15 @@
     ~/.config/alacritty:
       create: true
       path: config/alacritty
-    ~/.config/rustfmt:
+    ~/.config/bat:
       create: true
-      path: config/rustfmt
+      path: config/bat
     ~/.config/nvim:
       create: true
       path: config/nvim
+    ~/.config/rustfmt:
+      create: true
+      path: config/rustfmt
     ~/.config/starship:
       create: true
       path: config/starship

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -6,7 +6,7 @@ export HOMEBREW_CASK_OPTS="--no-quarantine"
 
 # Syntax highlighting for man pages using bat
 # export MANPAGER="sh -c 'col -bx | bat -l man -p'"
-export BAT_PAGER="less -RF"
+# export BAT_PAGER="less -RF"
 
 # C++ Flags.
 CPPFLAGS="-I/opt/homebrew/opt/openjdk/include"

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -7,6 +7,8 @@ export HOMEBREW_CASK_OPTS="--no-quarantine"
 # Syntax highlighting for man pages using bat
 # export MANPAGER="sh -c 'col -bx | bat -l man -p'"
 # export BAT_PAGER="less -RF"
+# Use bat for (instead of default cat) null commands.
+export NULLCMD=bat
 
 # C++ Flags.
 CPPFLAGS="-I/opt/homebrew/opt/openjdk/include"


### PR DESCRIPTION
Syntax highlighting for special custom files

## Added

- `.aliases` & `aliases` as `sh` file
- `.functions` & `functions` as `sh` file